### PR TITLE
Remove DCAP from variable and update default sgx sdk version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The other roles (such as the munin-node, timezone and keyboard roles) are not ye
 ## Requirements
 * Ansible v2.8 is required on your HOST (provisioner) system.
 * You must have `sshpass` installed on your HOST (provisioner) not on the GUEST (machine(s) being provisioned).
-* The GUEST machine must be on Ubuntu
+* The GUEST machine must be on Ubuntu 20.04 or 18.04
 * SGX must be enabled in your BIOS
 
 ### Before starting

--- a/README.md
+++ b/README.md
@@ -16,9 +16,12 @@ The other roles (such as the munin-node, timezone and keyboard roles) are not ye
 ## Requirements
 * Ansible v2.8 is required on your HOST (provisioner) system.
 * You must have `sshpass` installed on your HOST (provisioner) not on the GUEST (machine(s) being provisioned).
-* the GUEST machine must be on Ubuntu 20.04 (still oparating on Ubuntu 18.04? Contact us, we have a script for that one as well)
+* The GUEST machine must be on Ubuntu
 * SGX must be enabled in your BIOS
-* Processor must support FLC (don't know about that? check out this [section](https://github.com/integritee-network/sgx-setup#check-for-flc-support))
+
+### Before starting
+* Check if your processor supports FLC (don't know about that? check out this [section](https://github.com/integritee-network/sgx-setup#check-for-flc-support))
+* This script was tested on Ubuntu 20.04 but it should also support different Ubuntu versions. In case it does not work, please contact us.
 
 ## Steps
 

--- a/sgx-ansible/group_vars/buildServersSGX.yml
+++ b/sgx-ansible/group_vars/buildServersSGX.yml
@@ -55,7 +55,7 @@ intel_sgx_driver_installed_version_filename: "installed-intel-sgx-driver-version
 
 # the version of the intel sgx for linux
 # provide the selected version from https://download.01.org/intel-sgx/sgx-linux/
-intel_sgx_SDK_PWD_version: "2.14"
+intel_sgx_SDK_PWD_version: "2.15.1"
 
 intel_sgx_SDK_PWD_directory: "linux-{{ intel_sgx_SDK_PWD_version }}"
 intel_sgx_sdk_psw_linked_version_filename: "linked-sgx-sdk-version.txt"

--- a/sgx-ansible/group_vars/buildServersSGX.yml
+++ b/sgx-ansible/group_vars/buildServersSGX.yml
@@ -26,14 +26,31 @@ docker_users: [ 'uexample' ]
 # the following variables refer to role-intel-sgx
 intel_sgx_umbrella_directory: "/opt/intel"
 
-# the version of the intel DCAP sgx driver for linux
+# Intel provides three differnt driver versions: In-Kernel, DCAP and Out-of-tree Driver.
+# According to the intel intallation guide (<https://download.01.org/intel-sgx/sgx-linux/2.14/docs/Intel_SGX_SW_Installation_Guide_for_Linux.pdf>)
+# 1. In-kernel Driver: Mainline kernel release 5.11 or higher
+#   includes the SGX In-Kernel driver. The In-Kernel Driver requires the platform to support and to
+#   be configured for Flexible Launch Control (FLC).
+# 2. DCAP Driver: The goal of the DCAP driver is to provide an
+#   interface close to the In-kernel Driver in order to provide Intel® SGX support to Linux OSs that do
+#   not have the Intel® SGX driver built into the kernel. This driver also requires the platform to
+#   support and to be configured for Flexible Launch Control.
+# 3. Out-of-tree Driver (/dev/isgx): This driver is provided to support running Intel® SGX enclaves on
+#   platforms that only support Legacy Launch Control.  It may also be installed on platforms
+#   configured with Flexible Launch Control; however, then these platforms will only load enclaves
+#   that conform to the Legacy Launch Control Policy.
+
+# The version of the intel sgx driver for linux.
 # provide the version from https://download.01.org/intel-sgx/sgx-linux/{{intel_sgx_SDK_PWD_version}}/distro/ubuntu20.04-server/
 # example: https://download.01.org/intel-sgx/sgx-linux/2.14/distro/ubuntu20.04-server/
-# Sidenote: Driver version will not be updated anymore - 1.41 (according to intel) is the last one that is not directly incoorperated into the
+# Sidenote: Driver version will not be updated anymore - v1.41 (according to intel) is the last one that is not directly incoorperated into the
 # linux main kernel (from v5.11 on)
-intel_DCAP_DRIVER_version: "1.41"
+# In case your processor does not support FLC, choose the out-of-tree driver (OOT), specified in the driver_readme.txt file.
+# example DCAP version: "1.41"
+# example OOT version: "2.11.0_2d2b795"
+intel_DRIVER_version: "1.41"
 
-intel_sgx_DRIVER_directory: "linux-{{ intel_DCAP_DRIVER_version }}"
+intel_sgx_DRIVER_directory: "linux-{{ intel_DRIVER_version }}_driver"
 intel_sgx_driver_installed_version_filename: "installed-intel-sgx-driver-version.txt"
 
 # the version of the intel sgx for linux

--- a/sgx-ansible/group_vars/developmentServersSGX.yml
+++ b/sgx-ansible/group_vars/developmentServersSGX.yml
@@ -28,19 +28,37 @@ docker_users: [ 'uexample' ]
 # the following variables refer to role-intel-sgx
 intel_sgx_umbrella_directory: "/opt/intel"
 
-# the version of the intel DCAP sgx driver for linux
+
+# Intel provides three differnt driver versions: In-Kernel, DCAP and Out-of-tree Driver.
+# According to the intel intallation guide (<https://download.01.org/intel-sgx/sgx-linux/2.14/docs/Intel_SGX_SW_Installation_Guide_for_Linux.pdf>)
+# 1. In-kernel Driver: Mainline kernel release 5.11 or higher
+#   includes the SGX In-Kernel driver. The In-Kernel Driver requires the platform to support and to
+#   be configured for Flexible Launch Control (FLC).
+# 2. DCAP Driver: The goal of the DCAP driver is to provide an
+#   interface close to the In-kernel Driver in order to provide Intel® SGX support to Linux OSs that do
+#   not have the Intel® SGX driver built into the kernel. This driver also requires the platform to
+#   support and to be configured for Flexible Launch Control.
+# 3. Out-of-tree Driver (/dev/isgx): This driver is provided to support running Intel® SGX enclaves on
+#   platforms that only support Legacy Launch Control.  It may also be installed on platforms
+#   configured with Flexible Launch Control; however, then these platforms will only load enclaves
+#   that conform to the Legacy Launch Control Policy.
+
+# The version of the intel sgx driver for linux.
 # provide the version from https://download.01.org/intel-sgx/sgx-linux/{{intel_sgx_SDK_PWD_version}}/distro/ubuntu20.04-server/
 # example: https://download.01.org/intel-sgx/sgx-linux/2.14/distro/ubuntu20.04-server/
-# Sidenote: Driver version will not be updated anymore - 1.41 (according to intel) is the last one that is not directly incoorperated into the
+# Sidenote: Driver version will not be updated anymore - v1.41 (according to intel) is the last one that is not directly incoorperated into the
 # linux main kernel (from v5.11 on)
-intel_DCAP_DRIVER_version: "1.41"
+# In case your processor does not support FLC, choose the out-of-tree driver (OOT), specified in the driver_readme.txt file.
+# example DCAP version: "1.41"
+# example OOT version: "2.11.0_2d2b795"
+intel_DRIVER_version: "1.41"
 
-intel_sgx_DRIVER_directory: "linux-{{ intel_DCAP_DRIVER_version }}_DCAP_driver"
+intel_sgx_DRIVER_directory: "linux-{{ intel_DRIVER_version }}_driver"
 intel_sgx_driver_installed_version_filename: "installed-intel-sgx-driver-version.txt"
 
 # the version of the intel sgx for linux
 # provide the selected version from https://download.01.org/intel-sgx/sgx-linux/
-intel_sgx_SDK_PWD_version: "2.14"
+intel_sgx_SDK_PWD_version: "2.15.1"
 
 intel_sgx_SDK_PWD_directory: "linux-sgx_{{ intel_sgx_SDK_PWD_version }}"
 intel_sgx_sdk_psw_linked_version_filename: "linked-sgx-sdk-version.txt"

--- a/sgx-ansible/roles/role-intel-sgx/README.md
+++ b/sgx-ansible/roles/role-intel-sgx/README.md
@@ -12,7 +12,7 @@ Role Variables
 Intel sgx driver and SDK are now installed according to: <https://download.01.org/intel-sgx/sgx-linux/2.14/docs/Intel_SGX_SW_Installation_Guide_for_Linux.pdf> (version 2.14)
 
 The driver can be uninstalled with :
-cd /opt/intel/{intel_DCAP_DRIVER_version}/sgxdriver
+cd /opt/intel/{intel_DRIVER_version}/sgxdriver
 Use uninstall script to uninstall the driver:
 ./uninstall.sh
 
@@ -28,10 +28,10 @@ This variable defines the version of the SDK and PWD that will be installed. Thi
 intel_sgx_SDK_PWD_directory: "linux-sgx_{{ intel_sgx_SDK_PWD_version }}"
 This variable defines the directory, where SDK and PWD. This directory is now associated with the sdk_version, to avoid overwriting a previous version with a newer one. However, it can be further modified, to install the same sdk version with possibly different make options.
 
-intel_DCAP_DRIVER_version: '2.14'
+intel_DRIVER_version: '2.14'
 This variable defines the version of the sgx driver that will be installed. This has to be a valid version, for more info look at the official github page here: https://github.com/intel/linux-sgx-driver/releases
 
-intel_sgx_DRIVER_directory: "linux-{{ intel_DCAP_DRIVER_version }}_DCAP_driver"
+intel_sgx_DRIVER_directory: "linux-{{ intel_DRIVER_version }}_driver"
 This variable defines the directory, where sgx driver. This directory is now associated with the sgx driver version, to avoid overwriting a previous version with a newer one. However, it can be further modified. Please not that to uninstall the SGX driver, follow the uninstalling description provided in https://download.01.org/intel-sgx/sgx-linux/2.14/docs/Intel_SGX_SW_Installation_Guide_for_Linux.pdf
 
 

--- a/sgx-ansible/roles/role-intel-sgx/README.md
+++ b/sgx-ansible/roles/role-intel-sgx/README.md
@@ -28,7 +28,7 @@ This variable defines the version of the SDK and PWD that will be installed. Thi
 intel_sgx_SDK_PWD_directory: "linux-sgx_{{ intel_sgx_SDK_PWD_version }}"
 This variable defines the directory, where SDK and PWD. This directory is now associated with the sdk_version, to avoid overwriting a previous version with a newer one. However, it can be further modified, to install the same sdk version with possibly different make options.
 
-intel_DRIVER_version: '2.14'
+intel_DRIVER_version: '1.41'
 This variable defines the version of the sgx driver that will be installed. This has to be a valid version, for more info look at the official github page here: https://github.com/intel/linux-sgx-driver/releases
 
 intel_sgx_DRIVER_directory: "linux-{{ intel_DRIVER_version }}_driver"

--- a/sgx-ansible/roles/role-intel-sgx/tasks/main.yml
+++ b/sgx-ansible/roles/role-intel-sgx/tasks/main.yml
@@ -17,14 +17,14 @@
       recurse: yes
     when: intel_sgx_directory_details.stat.exists == false
 
-  # Install DCAP driver
+  # Install intel SGX driver
   - name: Check if any version of Intel SGX Driver is installed, based on the existence of a txt file
     stat:
       path: "{{ intel_sgx_umbrella_directory}}/{{ intel_sgx_driver_installed_version_filename }}"
     register: intel_sgx_driver_exists
     changed_when: False
 
-  - name: Install dependencies for intel DCAP SGX driver
+  - name: Install dependencies for intel SGX driver
     apt:
        name: ['build-essential',
               'ocaml',
@@ -35,12 +35,12 @@
               'dkms']
        state: present
 
-  - name: "Checking if Intel SGX DCAP Driver directory exists"
+  - name: "Checking if Intel SGX Driver directory exists"
     stat:
       path: "{{ intel_sgx_umbrella_directory }}/{{ intel_sgx_DRIVER_directory }}"
     register: intel_sgx_driver_directory_details
 
-  - name: "Create Intel SGX DCAP Driver directory if it doesn't exist"
+  - name: "Create Intel SGX Driver directory if it doesn't exist"
     file:
       path: "{{ intel_sgx_umbrella_directory }}/{{ intel_sgx_DRIVER_directory }}"
       state: directory
@@ -48,14 +48,14 @@
       recurse: yes
     when: intel_sgx_driver_directory_details.stat.exists == false
 
-  - name: Get DCAP SGX-Driver install binaries, in case it doesn't exist at all
+  - name: Get SGX driver install binaries, in case it doesn't exist at all
     get_url:
-      url: "https://download.01.org/intel-sgx/sgx-linux/{{ intel_sgx_SDK_PWD_version }}/distro/{{ linux_distro }}-server/sgx_linux_x64_driver_{{ intel_DCAP_DRIVER_version }}.bin"
+      url: "https://download.01.org/intel-sgx/sgx-linux/{{ intel_sgx_SDK_PWD_version }}/distro/{{ linux_distro }}-server/sgx_linux_x64_driver_{{ intel_DRIVER_version }}.bin"
       dest: "{{ intel_sgx_umbrella_directory }}/{{ intel_sgx_DRIVER_directory }}/"
     when: intel_sgx_driver_exists.stat.exists == false
 
-  - name: Install SGX-Driver, in case it doesn't exist at all
-    script: intel-sgx-install-driver.sh {{ intel_DCAP_DRIVER_version }}
+  - name: Install SGX driver, in case it doesn't exist at all
+    script: intel-sgx-install-driver.sh {{ intel_DRIVER_version }}
     args:
       chdir: "{{ intel_sgx_umbrella_directory }}/{{ intel_sgx_DRIVER_directory }}/"
     when: intel_sgx_driver_exists.stat.exists == false
@@ -78,25 +78,25 @@
       chdir: "{{ intel_sgx_umbrella_directory }}/sgxdriver/"
     when:
       - sgx_driver_kernel_version_installed is not skipped
-      - " intel_DCAP_DRIVER_version not in sgx_driver_kernel_version_installed['content'] | b64decode | trim "
+      - " intel_DRIVER_version not in sgx_driver_kernel_version_installed['content'] | b64decode | trim "
       # - " kernel_version.stdout in sgx_driver_kernel_version_installed['content'] | b64decode | trim "
 
   - name: If SGX driver mismatch detected - get the desired SGX-Driver version
     get_url:
-      url: "https://download.01.org/intel-sgx/sgx-linux/{{ intel_sgx_SDK_PWD_version }}/distro/{{ linux_distro }}-server/sgx_linux_x64_driver_{{ intel_DCAP_DRIVER_version }}.bin"
+      url: "https://download.01.org/intel-sgx/sgx-linux/{{ intel_sgx_SDK_PWD_version }}/distro/{{ linux_distro }}-server/sgx_linux_x64_driver_{{ intel_DRIVER_version }}.bin"
       dest: "{{ intel_sgx_umbrella_directory }}/{{ intel_sgx_DRIVER_directory }}/"
     when:
       - sgx_driver_kernel_version_installed is not skipped
-      - " intel_DCAP_DRIVER_version not in sgx_driver_kernel_version_installed['content'] | b64decode | trim "
+      - " intel_DRIVER_version not in sgx_driver_kernel_version_installed['content'] | b64decode | trim "
       # - " kernel_version.stdout in sgx_driver_kernel_version_installed['content'] | b64decode | trim "
 
   - name: If SGX driver mismatch detected - install the desired SGX-Driver version
-    script: intel-sgx-install-driver.sh {{ intel_DCAP_DRIVER_version }}
+    script: intel-sgx-install-driver.sh {{ intel_DRIVER_version }}
     args:
       chdir: "{{ intel_sgx_umbrella_directory }}/{{ intel_sgx_DRIVER_directory }}/"
     when:
       - sgx_driver_kernel_version_installed['content'] is defined
-      - " intel_DCAP_DRIVER_version not in sgx_driver_kernel_version_installed['content'] | b64decode | trim "
+      - " intel_DRIVER_version not in sgx_driver_kernel_version_installed['content'] | b64decode | trim "
       # - " kernel_version.stdout in sgx_driver_kernel_version_installed['content'] | b64decode | trim "
 
   - name: If SGX driver mismatch detected - update the txt file with the new sgx driver version
@@ -106,11 +106,11 @@
       force: yes
     when:
       - sgx_driver_kernel_version_installed is not skipped
-      - " intel_DCAP_DRIVER_version not in sgx_driver_kernel_version_installed['content'] | b64decode | trim "
+      - " intel_DRIVER_version not in sgx_driver_kernel_version_installed['content'] | b64decode | trim "
       # - " kernel_version.stdout in sgx_driver_kernel_version_installed['content'] | b64decode | trim "
 
   - name: "Detect if there is a mismatch in the kernel version --> install the driver at the new version"
-    script: intel-sgx-install-driver.sh {{ intel_DCAP_DRIVER_version }}
+    script: intel-sgx-install-driver.sh {{ intel_DRIVER_version }}
     args:
       chdir: "{{ intel_sgx_umbrella_directory }}/{{ intel_sgx_DRIVER_directory }}/"
     when:

--- a/sgx-ansible/roles/role-intel-sgx/templates/installed-sgx-driver-and-kernel-vers.j2
+++ b/sgx-ansible/roles/role-intel-sgx/templates/installed-sgx-driver-and-kernel-vers.j2
@@ -1,2 +1,2 @@
-{{ intel_DCAP_DRIVER_version }}
+{{ intel_DRIVER_version }}
 {{ kernel_version.stdout }}

--- a/sgx-ansible/roles/role-intel-sgx/templates/sgx-version.j2
+++ b/sgx-ansible/roles/role-intel-sgx/templates/sgx-version.j2
@@ -14,7 +14,7 @@ echo "\____ |\___  >\_//____  >___  /__/\_ \ "
 echo "     \/    \/         \/_____/      \/ "
 echo ""
 echo "The following versions are installed on this machine:"
-echo "- Intel SGX driver: DCAP " {{ intel_DCAP_DRIVER_version }}
+echo "- Intel SGX driver: " {{ intel_DRIVER_version }}
 echo "- Intel SGX SDK and PSW:" {{ intel_sgx_SDK_PWD_version }}
 echo ""
 echo "$(tput sgr0)"


### PR DESCRIPTION
- Removes DCAP from the variable names, as the oot installation can be done the exact same way. 
- Adds some description to driver version difference.
- Updates default sgx sdk version to most recent.

- [x] Update README - non-FLC support is now available. Just need to adapt driver accordingly.
- [x] rebase to updated main branch

Tested on devsgx01 and it worked (except for aesm, which will be fixed with PR #7 )